### PR TITLE
Auto corrected by following Lint Ruby Lint/UnusedBlockArgument

### DIFF
--- a/script/spec_server
+++ b/script/spec_server
@@ -98,7 +98,7 @@ end
 
 options = Hash.new
 opts = OptionParser.new
-opts.on("-d", "--daemon"){|v| options[:daemon] = true }
+opts.on("-d", "--daemon"){|_v| options[:daemon] = true }
 opts.on("-p", "--pid PIDFILE"){|v| options[:pid] = v }
 opts.parse!(ARGV)
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/UnusedBlockArgument

Click [here](https://awesomecode.io/repos/larssg/score-keeper/lint_configs/ruby/88994) to configure it on awesomecode.io