### PR TITLE
Auto corrected by following Lint Ruby Style/EmptyLiteral

### DIFF
--- a/script/spec_server
+++ b/script/spec_server
@@ -96,7 +96,7 @@ def daemonize(pid_file = nil)
   exit! 0
 end
 
-options = Hash.new
+options = {}
 opts = OptionParser.new
 opts.on("-d", "--daemon"){|v| options[:daemon] = true }
 opts.on("-p", "--pid PIDFILE"){|v| options[:pid] = v }


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/EmptyLiteral

Click [here](https://awesomecode.io/repos/larssg/score-keeper/lint_configs/ruby/89237) to configure it on awesomecode.io