### PR TITLE
Auto corrected by following Lint Ruby Style/RedundantRegexpEscape

### DIFF
--- a/features/step_definitions/webrat_steps.rb
+++ b/features/step_definitions/webrat_steps.rb
@@ -11,25 +11,25 @@ When /^I go to (.+)$/ do |page_name|
   visit path_to(page_name)
 end
 
-When /^I press "([^\"]*)"$/ do |button|
+When /^I press "([^"]*)"$/ do |button|
   click_button(button)
 end
 
-When /^I follow "([^\"]*)"$/ do |link|
+When /^I follow "([^"]*)"$/ do |link|
   click_link(link)
 end
 
-When /^I fill in "([^\"]*)" with "([^\"]*)"$/ do |field, value|
+When /^I fill in "([^"]*)" with "([^"]*)"$/ do |field, value|
   fill_in(field, :with => value) 
 end
 
-When /^I select "([^\"]*)" from "([^\"]*)"$/ do |value, field|
+When /^I select "([^"]*)" from "([^"]*)"$/ do |value, field|
   select(value, :from => field) 
 end
 
 # Use this step in conjunction with Rail's datetime_select helper. For example:
 # When I select "December 25, 2008 10:00" as the date and time 
-When /^I select "([^\"]*)" as the date and time$/ do |time|
+When /^I select "([^"]*)" as the date and time$/ do |time|
   select_datetime(time)
 end
 
@@ -42,7 +42,7 @@ end
 # The following steps would fill out the form:
 # When I select "November 23, 2004 11:20" as the "Preferred" date and time
 # And I select "November 25, 2004 10:30" as the "Alternative" date and time
-When /^I select "([^\"]*)" as the "([^\"]*)" date and time$/ do |datetime, datetime_label|
+When /^I select "([^"]*)" as the "([^"]*)" date and time$/ do |datetime, datetime_label|
   select_datetime(datetime, :from => datetime_label)
 end
 
@@ -50,67 +50,67 @@ end
 # When I select "2:20PM" as the time
 # Note: Rail's default time helper provides 24-hour time-- not 12 hour time. Webrat
 # will convert the 2:20PM to 14:20 and then select it. 
-When /^I select "([^\"]*)" as the time$/ do |time|
+When /^I select "([^"]*)" as the time$/ do |time|
   select_time(time)
 end
 
 # Use this step when using multiple time_select helpers on a page or you want to
 # specify the name of the time on the form.  For example:
 # When I select "7:30AM" as the "Gym" time
-When /^I select "([^\"]*)" as the "([^\"]*)" time$/ do |time, time_label|
+When /^I select "([^"]*)" as the "([^"]*)" time$/ do |time, time_label|
   select_time(time, :from => time_label)
 end
 
 # Use this step in conjunction with Rail's date_select helper.  For example:
 # When I select "February 20, 1981" as the date
-When /^I select "([^\"]*)" as the date$/ do |date|
+When /^I select "([^"]*)" as the date$/ do |date|
   select_date(date)
 end
 
 # Use this step when using multiple date_select helpers on one page or
 # you want to specify the name of the date on the form. For example:
 # When I select "April 26, 1982" as the "Date of Birth" date
-When /^I select "([^\"]*)" as the "([^\"]*)" date$/ do |date, date_label|
+When /^I select "([^"]*)" as the "([^"]*)" date$/ do |date, date_label|
   select_date(date, :from => date_label)
 end
 
-When /^I check "([^\"]*)"$/ do |field|
+When /^I check "([^"]*)"$/ do |field|
   check(field) 
 end
 
-When /^I uncheck "([^\"]*)"$/ do |field|
+When /^I uncheck "([^"]*)"$/ do |field|
   uncheck(field) 
 end
 
-When /^I choose "([^\"]*)"$/ do |field|
+When /^I choose "([^"]*)"$/ do |field|
   choose(field)
 end
 
-When /^I attach the file at "([^\"]*)" to "([^\"]*)"$/ do |path, field|
+When /^I attach the file at "([^"]*)" to "([^"]*)"$/ do |path, field|
   attach_file(field, path)
 end
 
-Then /^I should see "([^\"]*)"$/ do |text|
+Then /^I should see "([^"]*)"$/ do |text|
   response.should contain(text)
 end
 
-Then /^I should not see "([^\"]*)"$/ do |text|
+Then /^I should not see "([^"]*)"$/ do |text|
   response.should_not contain(text)
 end
 
-Then /^the "([^\"]*)" field should contain "([^\"]*)"$/ do |field, value|
+Then /^the "([^"]*)" field should contain "([^"]*)"$/ do |field, value|
   field_labeled(field).value.should =~ /#{value}/
 end
 
-Then /^the "([^\"]*)" field should not contain "([^\"]*)"$/ do |field, value|
+Then /^the "([^"]*)" field should not contain "([^"]*)"$/ do |field, value|
   field_labeled(field).value.should_not =~ /#{value}/
 end
     
-Then /^the "([^\"]*)" checkbox should be checked$/ do |label|
+Then /^the "([^"]*)" checkbox should be checked$/ do |label|
   field_labeled(label).should be_checked
 end
 
-Then /^the "([^\"]*)" checkbox should not be checked$/ do |label|
+Then /^the "([^"]*)" checkbox should not be checked$/ do |label|
   field_labeled(label).should_not be_checked
 end
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/RedundantRegexpEscape

Click [here](https://awesomecode.io/repos/larssg/score-keeper/lint_configs/ruby/90177) to configure it on awesomecode.io