### PR TITLE
Auto corrected by following Lint Javascript unicorn/no-hex-escape

### DIFF
--- a/public/javascripts/jquery.js
+++ b/public/javascripts/jquery.js
@@ -866,9 +866,9 @@ if ( indexOf ) {
 }
 
 // IE doesn't match non-breaking spaces with \s
-if ( rnotwhite.test( "\xA0" ) ) {
-	trimLeft = /^[\s\xA0]+/;
-	trimRight = /[\s\xA0]+$/;
+if ( rnotwhite.test( "\u00A0" ) ) {
+	trimLeft = /^[\s\u00A0]+/;
+	trimRight = /[\s\u00A0]+$/;
 }
 
 // All jQuery objects should point back to these


### PR DESCRIPTION
Auto corrected by following Lint Javascript unicorn/no-hex-escape

Click [here](https://awesomecode.io/repos/larssg/score-keeper/lint_configs/javascript/89484) to configure it on awesomecode.io